### PR TITLE
Sudo option for perfquery on mod_ib.c

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,3 +1,8 @@
+
+SUDO=1
+
 all:
-	gcc -fpic -I/usr/include/apr-1 -I/usr/include/apr-1.0 -I/opt/ganglia/include -D_LARGEFILE64_SOURCE -Wall -c mod_ib.c -o mod_ib.o
+	gcc -fpic -DSUDO=$(SUDO) -I/usr/include/apr-1 -I/usr/include/apr-1.0 -I/opt/ganglia/include -D_LARGEFILE64_SOURCE -Wall -c mod_ib.c -o mod_ib.o
 	ld -shared mod_ib.o -ldl -lnsl -lexpat -lconfuse -lapr-1 -lpthread -soname modInfiniband.so -o modInfiniband.so
+clean:
+	rm -f *.o *.so

--- a/mod_ib.c
+++ b/mod_ib.c
@@ -67,7 +67,12 @@ static g_val_t ib_metric_handler ( int metric_index )
 
     }
     if (data >= 4000000000){
+#if SUDO == 1
+	    if (system( "sudo /usr/sbin/perfquery -R")) {
+#else
 	    if (system( "/usr/sbin/perfquery -R")) {
+#endif
+
 		}
 	}
     val.uint32 = data;

--- a/mod_ib.c
+++ b/mod_ib.c
@@ -67,7 +67,7 @@ static g_val_t ib_metric_handler ( int metric_index )
 
     }
     if (data >= 4000000000){
-	    if (system( "/usr/sbin/perfquery -R -a")) {
+	    if (system( "/usr/sbin/perfquery -R")) {
 		}
 	}
     val.uint32 = data;

--- a/mod_ib.c
+++ b/mod_ib.c
@@ -66,7 +66,7 @@ static g_val_t ib_metric_handler ( int metric_index )
             data = 0;
 
     }
-    if (data >= 4000000000){
+    if (data >= 3000000000){
 #if SUDO == 1
 	    if (system( "sudo /usr/sbin/perfquery -R")) {
 #else


### PR DESCRIPTION
Hi, on our installation we need to use SUDO to call perfquery -R, also we remove -a from perfquery as don't want to reset all the IB counters just the local ones.

It might be usefull to other installation, if not, I will keep changes on mine.

Thanks!
